### PR TITLE
Add ADR MSE Loss

### DIFF
--- a/rankers/train/loss/torch/listwise.py
+++ b/rankers/train/loss/torch/listwise.py
@@ -234,6 +234,9 @@ class ADRMSE(BaseLoss):
     """
     Approx Discounted Rank MSE (ADR-MSE) as proposed by Schlatt et al. 
             https://dl.acm.org/doi/10.1007/978-3-031-88714-7_31
+
+    Implementation from: 
+        github.com/webis-de/lightning-ir/blob/main/lightning_ir/loss/loss.py
     """
     
     name = "ADR_MSE"


### PR DESCRIPTION
Adding Approx Discounted Rank MSE (ADR-MSE) loss as proposed by Schlatt et al. in their ECIR 2025 paper (https://dl.acm.org/doi/10.1007/978-3-031-88714-7_31).