### PR TITLE
refactor: group size is now a parameter of forward

### DIFF
--- a/examples/evaluation.py
+++ b/examples/evaluation.py
@@ -53,9 +53,9 @@ def evaluate_with_ir_metrics_example():
     model = Dot.from_pretrained(model_args.model_name_or_path, config=model_config)
 
     # Load training dataset
+    # group_size is inferred from the dataset's first entry
     train_dataset = TrainingDataset(
         data_args.training_dataset_file,
-        group_size=training_args.group_size,
     )
 
     # Load evaluation dataset from TREC format

--- a/examples/lora_adapters.py
+++ b/examples/lora_adapters.py
@@ -66,9 +66,9 @@ def train_with_lora_basic_example():
     model.print_trainable_parameters()
 
     # Load dataset
+    # group_size is inferred from the dataset's first entry
     dataset = TrainingDataset(
         data_args.training_dataset_file,
-        group_size=training_args.group_size,
     )
 
     collate_fn = DotDataCollator(model.tokenizer)

--- a/examples/train.bert.cat.py
+++ b/examples/train.bert.cat.py
@@ -24,9 +24,9 @@ def main():
 
     model = Cat.from_pretrained(model_args.model_name_or_path)
 
+    # group_size is inferred from the dataset's first entry
     dataset = TrainingDataset(
         data_args.training_dataset_file,
-        group_size=training_args.group_size,
         corpus=data_args.ir_dataset,
         no_positive=data_args.no_positive,
         teacher_file=data_args.teacher_file,

--- a/examples/train.bert.dot.py
+++ b/examples/train.bert.dot.py
@@ -26,9 +26,9 @@ def main():
     )
     model = Dot.from_pretrained(model_args.model_name_or_path, config=model_config)
 
+    # group_size is inferred from the dataset's first entry
     dataset = TrainingDataset(
         data_args.training_dataset_file,
-        group_size=training_args.group_size,
         corpus=data_args.ir_dataset,
         no_positive=data_args.no_positive,
         teacher_file=data_args.teacher_file,

--- a/examples/training.py
+++ b/examples/training.py
@@ -49,9 +49,9 @@ def train_dot_basic_example():
     model = Dot.from_pretrained(model_args.model_name_or_path, config=model_config)
 
     # Load training dataset
+    # group_size is inferred from the dataset's first entry
     dataset = TrainingDataset(
         data_args.training_dataset_file,
-        group_size=training_args.group_size,
         corpus=data_args.ir_dataset,
         no_positive=data_args.no_positive,
         teacher_file=data_args.teacher_file,
@@ -98,9 +98,9 @@ def train_with_custom_loss_example():
     )
     model = Dot.from_pretrained(model_args.model_name_or_path, config=model_config)
 
+    # group_size is inferred from the dataset's first entry
     dataset = TrainingDataset(
         data_args.training_dataset_file,
-        group_size=training_args.group_size,
     )
 
     collate_fn = DotDataCollator(model.tokenizer)
@@ -133,9 +133,9 @@ def train_cat_example():
     # Load Cat model
     model = Cat.from_pretrained(model_args.model_name_or_path)
 
+    # group_size is inferred from the dataset's first entry
     dataset = TrainingDataset(
         data_args.training_dataset_file,
-        group_size=training_args.group_size,
         corpus=data_args.ir_dataset,
     )
 
@@ -199,15 +199,14 @@ def train_with_regularization_example():
     Training with custom group size and regularization loss.
 
     This demonstrates:
-    - Custom group size for triplet sampling
+    - Explicit group size for training (overriding dataset inference)
     - Adding regularization loss (e.g., FLOPs regularization)
     - Fine-tuning pre-trained models
     """
     parser = HfArgumentParser((RankerDotArguments, RankerDataArguments, RankerTrainingArguments))
     model_args, data_args, training_args = parser.parse_args_into_dataclasses()
 
-    # Set group size and regularization
-    training_args.group_size = 8  # 1 positive + 7 negatives per query
+    # Set regularization
     training_args.regularization = "flops_reg"
     training_args.regularization_weight = 0.01
 
@@ -217,9 +216,10 @@ def train_with_regularization_example():
     )
     model = Dot.from_pretrained(model_args.model_name_or_path, config=model_config)
 
+    # Specify group_size=8 to use 1 positive + 7 negatives per query
     dataset = TrainingDataset(
         data_args.training_dataset_file,
-        group_size=training_args.group_size,
+        group_size=8,
     )
 
     collate_fn = DotDataCollator(model.tokenizer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rankers"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
   "torch",
   "transformers",
@@ -14,7 +14,7 @@ dependencies = [
   "pandas",
   "more_itertools",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
   {name = "Andrew Parry", email = "0andrewparry@gmail.com"}
 ]

--- a/rankers/__init__.py
+++ b/rankers/__init__.py
@@ -36,7 +36,7 @@ from transformers.utils import _LazyModule
 
 from ._optional import is_pyterrier_available, is_torch_available
 
-__version__ = "0.0.6"
+__version__ = "0.1.0"
 
 if os.getenv("RANKERS_EAGER_IMPORTS") == "1":
     # Import the subpackages you normally expose lazily

--- a/rankers/datasets/distillation_dataset.py
+++ b/rankers/datasets/distillation_dataset.py
@@ -243,6 +243,12 @@ class DistillationDataset(Dataset):
             )
 
         total_docs = len(ranked_docs)
+
+        # Infer group_size from first entry if not explicitly set
+        if self.group_size == -1:
+            self.group_size = total_docs
+            self.n_docs = total_docs
+
         # If n_docs is -1, use all documents; otherwise validate requested amount
         if self.n_docs > 0:
             assert self.n_docs <= total_docs, (

--- a/rankers/datasets/training_dataset.py
+++ b/rankers/datasets/training_dataset.py
@@ -254,6 +254,14 @@ class TrainingDataset(Dataset):
 
         self.multi_negatives = isinstance(first_entry[self.negative_id_key], list)
         total_negs = len(first_entry[self.negative_id_key]) if self.multi_negatives else 1
+
+        # Infer group_size from first entry if not explicitly set
+        if self.group_size == -1:
+            # group_size = 1 positive + total_negs (unless no_positive)
+            inferred_group_size = (total_negs + 1) if not self.no_positive else total_negs
+            self.group_size = inferred_group_size
+            self.n_neg = total_negs
+
         # If n_neg is -1, use all negatives; otherwise validate requested amount
         if self.n_neg > 0:
             assert self.n_neg <= total_negs, (

--- a/rankers/modelling/base.py
+++ b/rankers/modelling/base.py
@@ -59,7 +59,7 @@ class Ranker(PreTrainedModel):
         self.tokenizer = tokenizer
 
     @abstractmethod
-    def prepare_outputs(self, logits, labels=None, group_size=-1):
+    def prepare_outputs(self, logits, labels=None, group_size=2):
         """Prepare model outputs for loss computation.
 
         This abstract method must be implemented by subclasses to transform raw model
@@ -207,7 +207,7 @@ class Ranker(PreTrainedModel):
             device=device,
         )
 
-    def forward(self, loss, sequences, labels=None, group_size=-1):
+    def forward(self, loss, sequences, labels=None, group_size=2):
         """Forward pass computing loss for a batch.
 
         Processes input sequences through the model and computes loss using the provided

--- a/rankers/modelling/base.py
+++ b/rankers/modelling/base.py
@@ -59,7 +59,7 @@ class Ranker(PreTrainedModel):
         self.tokenizer = tokenizer
 
     @abstractmethod
-    def prepare_outputs(self, logits, labels=None):
+    def prepare_outputs(self, logits, labels=None, group_size=-1):
         """Prepare model outputs for loss computation.
 
         This abstract method must be implemented by subclasses to transform raw model
@@ -154,8 +154,8 @@ class Ranker(PreTrainedModel):
                 model.save_pretrained("./my_ranker")
                 # Can later be loaded with: Dot.from_pretrained("./my_ranker")
         """
-        self.config.save_pretrained(model_dir)
         self.model.save_pretrained(model_dir)
+        self.config.save_pretrained(model_dir)
         self.tokenizer.save_pretrained(model_dir)
 
     def load_state_dict(self, model_dir):
@@ -207,7 +207,7 @@ class Ranker(PreTrainedModel):
             device=device,
         )
 
-    def forward(self, loss, sequences, labels=None):
+    def forward(self, loss, sequences, labels=None, group_size=-1):
         """Forward pass computing loss for a batch.
 
         Processes input sequences through the model and computes loss using the provided
@@ -230,7 +230,7 @@ class Ranker(PreTrainedModel):
         sequences = {k: v.to(self.model.device) for k, v in sequences.items()}
         labels = labels.to(self.model.device) if labels is not None else None
         logits = self.model(**sequences).logits
-        pred, labels = self.prepare_outputs(logits, labels)
+        pred, labels = self.prepare_outputs(logits, labels, group_size=group_size)
         loss_value = loss(pred) if labels is None else loss(pred, labels)
         if type(loss_value) is tuple:
             loss_value, to_log = loss_value  # unpack tuple

--- a/rankers/modelling/cat/cat.py
+++ b/rankers/modelling/cat/cat.py
@@ -126,7 +126,7 @@ class Cat(Ranker):
         """
         return super().from_pretrained(model_name_or_path, config, num_labels=num_labels, **kwargs)
 
-    def prepare_outputs(self, logits, labels=None, group_size=-1):
+    def prepare_outputs(self, logits, labels=None, group_size=2):
         """Prepare model outputs for loss computation.
 
         Applies log-softmax to classification logits and extracts relevance scores.

--- a/rankers/modelling/cat/cat.py
+++ b/rankers/modelling/cat/cat.py
@@ -126,7 +126,7 @@ class Cat(Ranker):
         """
         return super().from_pretrained(model_name_or_path, config, num_labels=num_labels, **kwargs)
 
-    def prepare_outputs(self, logits, labels=None):
+    def prepare_outputs(self, logits, labels=None, group_size=-1):
         """Prepare model outputs for loss computation.
 
         Applies log-softmax to classification logits and extracts relevance scores.
@@ -145,8 +145,10 @@ class Cat(Ranker):
             Assumes binary classification with shape (batch_size * group_size, 2).
             Extracts positive class probabilities (index 1).
         """
-        return F.log_softmax(logits.reshape(-1, self.config.group_size, 2), dim=-1)[:, :, 1], (
-            labels.view(-1, self.config.group_size) if labels is not None else None
+        if group_size == -1:
+            group_size = 1
+        return F.log_softmax(logits.reshape(-1, group_size, 2), dim=-1)[:, :, 1], (
+            labels.view(-1, group_size) if labels is not None else None
         )
 
 

--- a/rankers/modelling/dot/dot.py
+++ b/rankers/modelling/dot/dot.py
@@ -252,7 +252,7 @@ class Dot(Ranker):
 
             self.transformer_class = DotTransformer
 
-    def prepare_outputs(self, query_reps, docs_batch_reps, labels=None, group_size=-1):
+    def prepare_outputs(self, query_reps, docs_batch_reps, labels=None, group_size=2):
         if group_size == -1:
             group_size = 1
         batch_size = query_reps.size(0)
@@ -294,7 +294,7 @@ class Dot(Ranker):
     def _encode_q(self, **text):
         return self.pooling(self.model(**text).last_hidden_state)
 
-    def forward(self, loss=None, queries=None, docs_batch=None, labels=None, group_size=-1):
+    def forward(self, loss=None, queries=None, docs_batch=None, labels=None, group_size=2):
         """Forward pass computing ranking loss.
 
         Encodes queries and documents separately, computes dot-product scores, and

--- a/rankers/modelling/sparse/sparse.py
+++ b/rankers/modelling/sparse/sparse.py
@@ -219,7 +219,7 @@ class Sparse(Dot):
     def _encode_q(self, **text):
         return self.query_processing(self.model(**text), text["attention_mask"])
 
-    def forward(self, loss=None, queries=None, docs_batch=None, labels=None):
+    def forward(self, loss=None, queries=None, docs_batch=None, labels=None, group_size=-1):
         """Compute the loss given (queries, docs, labels)"""
         queries = (
             {k: v.to(self.model.device) for k, v in queries.items()}
@@ -236,7 +236,9 @@ class Sparse(Dot):
         query_reps = self._encode_q(**queries) if queries is not None else None
         docs_batch_reps = self._encode_d(**docs_batch) if docs_batch is not None else None
 
-        pred, labels, inbatch_pred = self.prepare_outputs(query_reps, docs_batch_reps, labels)
+        pred, labels, inbatch_pred = self.prepare_outputs(
+            query_reps, docs_batch_reps, labels, group_size=group_size
+        )
         inbatch_loss = (
             self.inbatch_loss_fn(
                 inbatch_pred, torch.eye(inbatch_pred.shape[0]).to(inbatch_pred.device)

--- a/rankers/modelling/sparse/sparse.py
+++ b/rankers/modelling/sparse/sparse.py
@@ -219,7 +219,7 @@ class Sparse(Dot):
     def _encode_q(self, **text):
         return self.query_processing(self.model(**text), text["attention_mask"])
 
-    def forward(self, loss=None, queries=None, docs_batch=None, labels=None, group_size=-1):
+    def forward(self, loss=None, queries=None, docs_batch=None, labels=None, group_size=2):
         """Compute the loss given (queries, docs, labels)"""
         queries = (
             {k: v.to(self.model.device) for k, v in queries.items()}

--- a/rankers/pyterrier/cat/cat.py
+++ b/rankers/pyterrier/cat/cat.py
@@ -64,11 +64,12 @@ class CatTransformer(pt.Transformer):
         model: PreTrainedModel,
         tokenizer: PreTrainedTokenizer,
         batch_size: int = 64,
+        device: Union[str, torch.device, None] = None,
         text_field: str = "text",
         verbose: bool = False,
     ):
         config = model.config
-        return cls(model, tokenizer, config, batch_size, text_field, model.device, verbose)
+        return cls(model, tokenizer, config, batch_size, text_field, device, verbose)
 
     def transform(self, inp: pd.DataFrame) -> pd.DataFrame:
         scores = []
@@ -121,11 +122,12 @@ class PairTransformer(pt.Transformer):
         model: PreTrainedModel,
         tokenizer: PreTrainedTokenizer,
         batch_size: int = 64,
+        device: Union[str, torch.device, None] = None,
         text_field: str = "text",
         verbose: bool = False,
     ):
         config = model.config
-        return cls(model, tokenizer, config, batch_size, text_field, model.device, verbose)
+        return cls(model, tokenizer, config, batch_size, text_field, device, verbose)
 
     @classmethod
     def from_pretrained(

--- a/rankers/pyterrier/sparse/sparse.py
+++ b/rankers/pyterrier/sparse/sparse.py
@@ -3,6 +3,7 @@ import itertools
 import re
 import string
 from contextlib import ExitStack
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -62,8 +63,8 @@ class SparseTransformer(pt.Transformer):
         cls,
         model,
         tokenizer,
-        device=None,
         batch_size=32,
+        device: Union[str, torch.device, None] = None,
         text_field="text",
         fp16=False,
         topk=None,

--- a/rankers/train/trainer.py
+++ b/rankers/train/trainer.py
@@ -147,7 +147,6 @@ class RankerTrainer(Trainer):
         # Only set tokenizer if data_collator has one
         if hasattr(self.data_collator, "tokenizer"):
             self.tokenizer = self.data_collator.tokenizer
-        self.model.config.group_size = self.args.group_size
 
     def compute_loss(
         self,
@@ -156,7 +155,7 @@ class RankerTrainer(Trainer):
         return_outputs=False,
         **kwargs,  # handle new arguments
     ):
-        outputs = model(self.loss, **inputs)
+        outputs = model(self.loss, **inputs, group_size=self.args.group_size)
         # Save past state if it exists
         if self.args.past_index >= 0:
             self._past = outputs[self.args.past_index]

--- a/rankers/train/trainer.py
+++ b/rankers/train/trainer.py
@@ -117,6 +117,11 @@ class RankerTrainer(Trainer):
         else:
             self.loss = loss_fn
 
+        # Infer group_size from train_dataset if available
+        self.group_size = 2  # default
+        if self.train_dataset is not None and hasattr(self.train_dataset, "group_size"):
+            self.group_size = self.train_dataset.group_size
+
         self.regularize_loss = False
         if self.args.regularization is not None:
             # if regularization is callable, use it directly
@@ -155,7 +160,7 @@ class RankerTrainer(Trainer):
         return_outputs=False,
         **kwargs,  # handle new arguments
     ):
-        outputs = model(self.loss, **inputs, group_size=self.args.group_size)
+        outputs = model(self.loss, **inputs, group_size=self.group_size)
         # Save past state if it exists
         if self.args.past_index >= 0:
             self._past = outputs[self.args.past_index]

--- a/rankers/train/training_arguments.py
+++ b/rankers/train/training_arguments.py
@@ -31,7 +31,6 @@ class RankerTrainingArguments(TrainingArguments):
     save_total_limit: Optional[int] = field(
         default=10, metadata={"help": "Limit the total amount of checkpoints."}
     )
-    group_size: Optional[int] = field(default=2, metadata={"help": "Number of documents per query"})
     eval_metrics: Optional[List[str]] = field(
         default_factory=lambda: [], metadata={"help": "Evaluation metrics"}
     )
@@ -55,7 +54,6 @@ class RankerTrainingArguments(TrainingArguments):
 
         if self.wandb_project is not None:
             os.environ["WANDB_PROJECT"] = self.wandb_project
-        assert self.group_size > 0, "Group size must be greater than 0"
 
         self.eval_ir_metrics = (
             [parse_ir_measure(metric) for metric in self.eval_metrics]

--- a/tests/unit/test_trainer_config.py
+++ b/tests/unit/test_trainer_config.py
@@ -11,18 +11,6 @@ from rankers.train.training_arguments import RankerTrainingArguments
 class TestRankerTrainingArguments:
     """Tests for RankerTrainingArguments configuration."""
 
-    def test_default_group_size(self):
-        """Test default group size."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            args = RankerTrainingArguments(output_dir=tmpdir)
-            assert args.group_size == 2
-
-    def test_custom_group_size(self):
-        """Test custom group size."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            args = RankerTrainingArguments(output_dir=tmpdir, group_size=8)
-            assert args.group_size == 8
-
     def test_eval_strategy_steps(self):
         """Test evaluation strategy with steps."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/test_trainer_init.py
+++ b/tests/unit/test_trainer_init.py
@@ -68,16 +68,6 @@ class TestRankerTrainerInit:
             trainer = RankerTrainer(model=model, args=args)
             assert trainer.loss is None
 
-    def test_init_sets_group_size_in_config(self):
-        """Test that group_size is properly set in model config."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            args = RankerTrainingArguments(output_dir=tmpdir, group_size=8)
-            model = TinyDotModel()
-
-            trainer = RankerTrainer(model=model, args=args, loss_fn="margin_mse")
-
-            assert model.config.group_size == 8
-
     def test_init_requires_output_dir(self):
         """Test that initialization requires output directory."""
         model = TinyDotModel()

--- a/tests/unit/test_trainer_metrics.py
+++ b/tests/unit/test_trainer_metrics.py
@@ -47,19 +47,6 @@ class TestRankerTrainerMetrics:
             assert args.eval_ir_metrics is not None
             assert len(args.eval_ir_metrics) == 2
 
-    def test_trainer_model_config_group_size(self):
-        """Test that model config group size is set from args."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            args = RankerTrainingArguments(
-                output_dir=tmpdir,
-                group_size=4,
-            )
-            model = TinyDotModel()
-
-            trainer = RankerTrainer(model=model, args=args, loss_fn="margin_mse")
-
-            assert model.config.group_size == 4
-
     def test_trainer_default_metrics_list(self):
         """Test that default eval metrics list is empty."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Currently, group_size is set in the internal config of ranking models; this step must be done explicitly in the trainer and would likely be missed if someone used rankers without the trainer. 

Instead now the group size ```group_size``` is a keyword argument added to forward and prepare_outputs. This makes it clearer what it does and where it comes from.

The current default is -1, which should be changed to a model-specific value. Setting it to align with the dataset's default is preferable. 

I am currently unsure what the deprecation strategy should be, as this is definitely a breaking change. 